### PR TITLE
 Reset seed inside "Subject" `else` clause

### DIFF
--- a/R/predict.jointModel.R
+++ b/R/predict.jointModel.R
@@ -277,8 +277,9 @@ function (object, newdata, type = c("Marginal", "Subject"),
                 rbind(newdata, cbind(data.id2, pred = out))
             }
         } else
-            attr(out, "time.to.pred") <- times.to.pred
+            attr(out, "time.to.pred") <- times.to.pred 
+    
+    rm(list = ".Random.seed", envir = globalenv())        
     }
-    rm(list = ".Random.seed", envir = globalenv())
     out
 }

--- a/man/predict.Rd
+++ b/man/predict.Rd
@@ -47,8 +47,7 @@
   let \eqn{X} denote the fixed-effects design matrix calculated using
   \code{newdata}. The \code{predict()} calculates \eqn{\hat{y} = X \hat{\beta}},
   and if \code{interval = "confidence"}, \eqn{var(\hat{y}) = X V X^t}, with \eqn{V}
-  denoting the covariance matrix of \eqn{\hat{\beta}}. The confidence interval
-  is based on a normal approximation. Confidence intervals are constructed under 
+  denoting the covariance matrix of \eqn{\hat{\beta}}. Confidence intervals are constructed under 
   the normal approximation.
   
   When \code{type = "Subject"}, this functions computes subject-specific 


### PR DESCRIPTION
Resetting the seed in the case the user has chosen marginal predictions results in a warning on a subsequent second run because no seed is generated after `.Random.seed` has been deleted. Only when a seed is created by a random number generator function inside the `else` clause starting in line 38, is `rm(list = ".Random.seed", envir = globalenv())` not causing this warning.